### PR TITLE
修复权限申请问题

### DIFF
--- a/lib/page/trtcmeetingdemo/index.dart
+++ b/lib/page/trtcmeetingdemo/index.dart
@@ -106,7 +106,7 @@ class IndexPageState extends State<IndexPage> {
     }
     unFocus();
     if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
-      if (!(await Permission.camera.request().isGranted) &&
+      if (!(await Permission.camera.request().isGranted) ||
           !(await Permission.microphone.request().isGranted)) {
         MeetingTool.toast('需要获取音视频权限才能进入', context);
         return;


### PR DESCRIPTION
用&&的话前面为假直接不执行后面的了 导致后面的权限申请不生效